### PR TITLE
Dev

### DIFF
--- a/src/detergent.erl
+++ b/src/detergent.erl
@@ -94,14 +94,14 @@ wsdl_op_action(#operation{action = Action}) -> Action.
 call(Wsdl, Operation, ListOfData) ->
     call(Wsdl, Operation, ListOfData, #call_opts{}).
 
-call(WsdlURL, Operation, ListOfData, #call_opts{prefix=DefaultPrefix}=CallOpts) 
+call(WsdlURL, Operation, ListOfData, #call_opts{prefix=Prefix}=CallOpts) 
     when is_list(WsdlURL) ->
-    Wsdl = initModel(WsdlURL, DefaultPrefix),
+    Wsdl = initModel(WsdlURL, Prefix),
     call(Wsdl, Operation, ListOfData, CallOpts);
-call(Wsdl, Operation, ListOfData, #call_opts{prefix=DefaultPrefix}=CallOpts) when is_record(Wsdl, wsdl) ->
+call(Wsdl, Operation, ListOfData, #call_opts{prefix=Prefix}=CallOpts) when is_record(Wsdl, wsdl) ->
     case get_operation(Wsdl#wsdl.operations, Operation) of
 	{ok, Op} ->
-	    Msg = mk_msg(DefaultPrefix, Operation, ListOfData),
+	    Msg = mk_msg(Prefix, Operation, ListOfData),
 	    call(Wsdl, Operation, Op#operation.port, 
                  Op#operation.service, [], Msg, CallOpts);
 	Else ->
@@ -115,9 +115,9 @@ call(Wsdl, Operation, Header, Msg) ->
 
 
 
-call(WsdlURL, Operation, Header, Msg, #call_opts{prefix=DefaultPrefix}=CallOpts) 
+call(WsdlURL, Operation, Header, Msg, #call_opts{prefix=Prefix}=CallOpts) 
     when is_list(WsdlURL) ->
-    Wsdl = initModel(WsdlURL, DefaultPrefix),
+    Wsdl = initModel(WsdlURL, Prefix),
     call(Wsdl, Operation, Header, Msg, CallOpts);
 call(Wsdl, Operation, Header, Msg, CallOpts) when is_record(Wsdl, wsdl) ->
     case get_operation(Wsdl#wsdl.operations, Operation) of


### PR DESCRIPTION
Two tiny commits.
1. The first one makes use of the 'prefix' field in all places where the ?DEFAULT_PREFIX macro was used before. This is actually a bug fix as without this, the prefix field in #call_opts{} was ignored.
2. The second is a cosmetic change, but makes the code less confusing to the reader.
