### PR TITLE
Add applications to app.src

### DIFF
--- a/src/detergent.app.src
+++ b/src/detergent.app.src
@@ -1,3 +1,7 @@
 {application, detergent,
  [{description, "An emulsifying Erlang SOAP library"},
-  {vsn, "0.3.0"}]}.
+  {vsn, "0.3.0"},
+  {modules,[]},
+  {registered, []},
+  {env, []},
+  {applications,[]}]}.


### PR DESCRIPTION
I was packaging an application (Elixir with exrm) and relx was complaining about _missing_param applications_
I have added _applications_ and also _mod_, _registered_ and _env_

On another note should _xmerl_ be declared in applications ? 
