### PR TITLE
Added applications info to stop distillery from failing

### DIFF
--- a/src/detergent.app.src
+++ b/src/detergent.app.src
@@ -1,3 +1,4 @@
 {application, detergent,
  [{description, "An emulsifying Erlang SOAP library"},
-  {vsn, "0.3.0"}]}.
+  {vsn, "0.3.0"},
+  {applications, [kernel, stdlib, erlsom]}]}.


### PR DESCRIPTION
`distillery` fails with the following error when I try to create a release. Adding `applications` to the `app.src` file fixes it. I am not sure if distillery is at fault here. Please let me know if this is an incorrect fix

```txt
==> Failed to build release:
    
    detergent: Missing parameter in .app file: applications
```