### PR TITLE
Forward http options to httpc request

### DIFF
--- a/src/detergent.erl
+++ b/src/detergent.erl
@@ -437,12 +437,13 @@ inets_request(URL, SoapAction, Request, Options, Headers, ContentType) ->
                          NHeaders
                  end,
     NewOptions = [{cookies, enabled}|Options],
+    HttpOptions = [{timeout,?HTTP_REQ_TIMEOUT}|Options],
     httpc:set_options(NewOptions),
     case httpc:request(post,
                       {URL,NewHeaders,
                        ContentType,
                        Request},
-                      [{timeout,?HTTP_REQ_TIMEOUT}],
+                      HttpOptions,
                       [{sync, true}, {full_result, true}, {body_format, string}]) of
         {ok,{{_HTTP,200,_OK},ResponseHeaders,ResponseBody}} ->
             {ok, 200, ResponseHeaders, ResponseBody};


### PR DESCRIPTION
This allows one to override any [http_option()](http://erlang.org/doc/man/httpc.html#request-4), like setting a custom timeout or specifying ssl options.