### PR TITLE
Allow Detergent to be built with Distillery

### DIFF
--- a/src/detergent.app.src
+++ b/src/detergent.app.src
@@ -1,3 +1,4 @@
 {application, detergent,
  [{description, "An emulsifying Erlang SOAP library"},
-  {vsn, "0.3.0"}]}.
+  {vsn, "0.3.0"},
+  {applications: []}]}.

--- a/src/detergent.app.src
+++ b/src/detergent.app.src
@@ -1,4 +1,4 @@
 {application, detergent,
  [{description, "An emulsifying Erlang SOAP library"},
   {vsn, "0.3.0"},
-  {applications: []}]}.
+  {applications, []}]}.


### PR DESCRIPTION
When I attempt to build an Elixir application that depends on Detergent via `MIX_ENV=prod mix release --env=prod`, I get this error:

```
==> Release failed, during .boot generation:
        detergent: Missing parameter in .app file: applications
```

Adding the blank applications list fixes it.